### PR TITLE
Fix Remotion versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,14 +22,14 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "@remotion/bundler": "4.0.182",
-    "@remotion/cli": "^4.0.182",
-    "@remotion/player": "4.0.182",
-    "@remotion/renderer": "4.0.182",
-    "@remotion/zod-types": "^4.0.182",
+    "@remotion/bundler": "4.0.252",
+    "@remotion/cli": "4.0.252",
+    "@remotion/player": "4.0.252",
+    "@remotion/renderer": "4.0.252",
+    "@remotion/zod-types": "4.0.252",
     "electron-log": "^5.1.5",
     "electron-updater": "^6.1.8",
-    "remotion": "^4.0.182"
+    "remotion": "4.0.252"
   },
   "devDependencies": {
     "@playwright/test": "^1.42.1",


### PR DESCRIPTION
### Description

A simple change to the package.json file locking all of the remotion deps to `4.0.252` as currently they're a mix of `^4.0.182` and `4.0.182` which causes a mismatch between packages. This change will allow the template to work out of the box again.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other
